### PR TITLE
DE-1976 rename type to link_type

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -459,7 +459,7 @@
   version = "2.0.0"
 
 [[projects]]
-  digest = "1:e94032b9caf7e9fb6c59280188df1058e9c66b6c15a90f4f5eb149daf5270904"
+  digest = "1:7cd7be5b4122b7711700c8ca42951e7a3f359f22351dd5ed894749c7b7d6343d"
   name = "github.com/pinpt/integration-sdk"
   packages = [
     ".",
@@ -471,8 +471,8 @@
     "work",
   ]
   pruneopts = "T"
-  revision = "a627a7795ecd507b93c0fdf2205c29f96c8ecc15"
-  version = "v0.0.673"
+  revision = "4bc4afc8a477508988538e9bf3ef6ddd47f9e14e"
+  version = "v0.0.675"
 
 [[projects]]
   branch = "master"

--- a/integrations/pkg/jiracommonapi/issues.go
+++ b/integrations/pkg/jiracommonapi/issues.go
@@ -289,19 +289,19 @@ func IssuesAndChangelogsPage(
 		item.Tags = fields.Labels
 
 		for _, link := range fields.IssueLinks {
-			var linkType work.IssueLinkedIssuesType
+			var linkType work.IssueLinkedIssuesLinkType
 			reverseDirection := false
 			switch link.Type.Name {
 			case "Blocks":
-				linkType = work.IssueLinkedIssuesTypeBlocks
+				linkType = work.IssueLinkedIssuesLinkTypeBlocks
 			case "Cloners":
-				linkType = work.IssueLinkedIssuesTypeClones
+				linkType = work.IssueLinkedIssuesLinkTypeClones
 			case "Duplicate":
-				linkType = work.IssueLinkedIssuesTypeDuplicates
+				linkType = work.IssueLinkedIssuesLinkTypeDuplicates
 			case "Problem/Incident":
-				linkType = work.IssueLinkedIssuesTypeCauses
+				linkType = work.IssueLinkedIssuesLinkTypeCauses
 			case "Relates":
-				linkType = work.IssueLinkedIssuesTypeRelates
+				linkType = work.IssueLinkedIssuesLinkTypeRelates
 			default:
 				qc.Logger.Error("unknown link type name", "name", link.Type.Name)
 				continue
@@ -322,7 +322,7 @@ func IssuesAndChangelogsPage(
 			link2.IssueRefID = linkedIssue.ID
 			link2.IssueIdentifier = linkedIssue.Key
 			link2.ReverseDirection = reverseDirection
-			link2.Type = linkType
+			link2.LinkType = linkType
 			item.LinkedIssues = append(item.LinkedIssues, link2)
 		}
 


### PR DESCRIPTION
theres a bug in schemagen that makes this inner field overwrite the outer issue.Type in go-common renaming will fix it until the new datamodel is rolled out.