### PR TITLE
AGT-52 use jira status api to fetch the status metadata

### DIFF
--- a/integrations/pkg/jiracommon/testdata/status.json
+++ b/integrations/pkg/jiracommon/testdata/status.json
@@ -1,0 +1,460 @@
+[
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/1",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/open.png",
+        "name": "Work Required",
+        "id": "1",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/3",
+        "description": "This issue is being actively worked on at the moment by the assignee.",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/inprogress.png",
+        "name": "In Progress",
+        "id": "3",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/4",
+            "id": 4,
+            "key": "indeterminate",
+            "colorName": "yellow",
+            "name": "In Progress"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/4",
+        "description": "This issue was once resolved, but the resolution was deemed incorrect. From here issues are either marked assigned or resolved.",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/reopened.png",
+        "name": "Rework",
+        "id": "4",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/6",
+        "description": "The issue is considered finished, the resolution is correct. Issues which are closed can be reopened.",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/closed.png",
+        "name": "Closed",
+        "id": "6",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/3",
+            "id": 3,
+            "key": "done",
+            "colorName": "green",
+            "name": "Done"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10000",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "To Do",
+        "id": "10000",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10201",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "Selected for Development",
+        "id": "10201",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10307",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/generic.png",
+        "name": "Awaiting Validation",
+        "id": "10307",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10309",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/generic.png",
+        "name": "Awaiting Release",
+        "id": "10309",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10324",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/generic.png",
+        "name": "Work Complete",
+        "id": "10324",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10325",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/generic.png",
+        "name": "In Testing",
+        "id": "10325",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10330",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "To Do",
+        "id": "10330",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        },
+        "scope": {
+            "type": "PROJECT",
+            "project": {
+                "id": "10626"
+            }
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10331",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "In Progress",
+        "id": "10331",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/4",
+            "id": 4,
+            "key": "indeterminate",
+            "colorName": "yellow",
+            "name": "In Progress"
+        },
+        "scope": {
+            "type": "PROJECT",
+            "project": {
+                "id": "10626"
+            }
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10332",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "Done",
+        "id": "10332",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/3",
+            "id": 3,
+            "key": "done",
+            "colorName": "green",
+            "name": "Done"
+        },
+        "scope": {
+            "type": "PROJECT",
+            "project": {
+                "id": "10626"
+            }
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10333",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "To Do",
+        "id": "10333",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        },
+        "scope": {
+            "type": "PROJECT",
+            "project": {
+                "id": "10627"
+            }
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10334",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "In Progress",
+        "id": "10334",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/4",
+            "id": 4,
+            "key": "indeterminate",
+            "colorName": "yellow",
+            "name": "In Progress"
+        },
+        "scope": {
+            "type": "PROJECT",
+            "project": {
+                "id": "10627"
+            }
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10335",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "Done",
+        "id": "10335",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/3",
+            "id": 3,
+            "key": "done",
+            "colorName": "green",
+            "name": "Done"
+        },
+        "scope": {
+            "type": "PROJECT",
+            "project": {
+                "id": "10627"
+            }
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10336",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "In Review",
+        "id": "10336",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/4",
+            "id": 4,
+            "key": "indeterminate",
+            "colorName": "yellow",
+            "name": "In Progress"
+        },
+        "scope": {
+            "type": "PROJECT",
+            "project": {
+                "id": "10627"
+            }
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10340",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "Backlog",
+        "id": "10340",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        },
+        "scope": {
+            "type": "PROJECT",
+            "project": {
+                "id": "10628"
+            }
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10341",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "In Review",
+        "id": "10341",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/4",
+            "id": 4,
+            "key": "indeterminate",
+            "colorName": "yellow",
+            "name": "In Progress"
+        },
+        "scope": {
+            "type": "PROJECT",
+            "project": {
+                "id": "10628"
+            }
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10342",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "Ready for Promotion",
+        "id": "10342",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/3",
+            "id": 3,
+            "key": "done",
+            "colorName": "green",
+            "name": "Done"
+        },
+        "scope": {
+            "type": "PROJECT",
+            "project": {
+                "id": "10628"
+            }
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10343",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/",
+        "name": "On Hold",
+        "id": "10343",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/4",
+            "id": 4,
+            "key": "indeterminate",
+            "colorName": "yellow",
+            "name": "In Progress"
+        },
+        "scope": {
+            "type": "PROJECT",
+            "project": {
+                "id": "10627"
+            }
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10346",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/generic.png",
+        "name": "Control Validation",
+        "id": "10346",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10347",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/generic.png",
+        "name": "Validated",
+        "id": "10347",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/3",
+            "id": 3,
+            "key": "done",
+            "colorName": "green",
+            "name": "Done"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10348",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/generic.png",
+        "name": "Evidence Needed",
+        "id": "10348",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10349",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/generic.png",
+        "name": "Gathering Evidence",
+        "id": "10349",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/4",
+            "id": 4,
+            "key": "indeterminate",
+            "colorName": "yellow",
+            "name": "In Progress"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10350",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/generic.png",
+        "name": "Validate Evidence",
+        "id": "10350",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10351",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/generic.png",
+        "name": "Evidence Validated",
+        "id": "10351",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/3",
+            "id": 3,
+            "key": "done",
+            "colorName": "green",
+            "name": "Done"
+        }
+    },
+    {
+        "self": "https://pinpt-hq.atlassian.net/rest/api/3/status/10356",
+        "description": "",
+        "iconUrl": "https://pinpt-hq.atlassian.net/images/icons/statuses/generic.png",
+        "name": "Acceptance",
+        "id": "10356",
+        "statusCategory": {
+            "self": "https://pinpt-hq.atlassian.net/rest/api/3/statuscategory/2",
+            "id": 2,
+            "key": "new",
+            "colorName": "blue-gray",
+            "name": "To Do"
+        }
+    }
+]

--- a/integrations/pkg/jiracommon/workconfig.go
+++ b/integrations/pkg/jiracommon/workconfig.go
@@ -36,7 +36,7 @@ func GetWorkConfig(qc jiracommonapi.QueryContext, isCloud bool, usesOauth bool) 
 	}
 	ws.Types = issueTypes
 
-	statusdetail, allStatus, err := jiracommonapi.StatusWithDetail(qc)
+	statusDetail, allStatus, err := jiracommonapi.StatusWithDetail(qc)
 	if err != nil {
 		res.Error = err
 		return
@@ -51,7 +51,7 @@ func GetWorkConfig(qc jiracommonapi.QueryContext, isCloud bool, usesOauth bool) 
 
 	ws.AllResolutions = resolutions
 
-	appendStaticInfo(&ws, statusdetail)
+	appendStaticInfo(&ws, statusDetail)
 
 	res.Data = ws.ToMap()
 	return

--- a/integrations/pkg/jiracommon/workconfig.go
+++ b/integrations/pkg/jiracommon/workconfig.go
@@ -36,7 +36,7 @@ func GetWorkConfig(qc jiracommonapi.QueryContext, isCloud bool, usesOauth bool) 
 	}
 	ws.Types = issueTypes
 
-	allStatus, err := jiracommonapi.Status(qc)
+	statusdetail, allStatus, err := jiracommonapi.StatusWithDetail(qc)
 	if err != nil {
 		res.Error = err
 		return
@@ -51,7 +51,7 @@ func GetWorkConfig(qc jiracommonapi.QueryContext, isCloud bool, usesOauth bool) 
 
 	ws.AllResolutions = resolutions
 
-	appendStaticInfo(&ws)
+	appendStaticInfo(&ws, statusdetail)
 
 	res.Data = ws.ToMap()
 	return
@@ -75,14 +75,21 @@ func getExistedStatusesOnly(allstatus, optns []string) []string {
 	return res
 }
 
-func appendStaticInfo(ws *agent.WorkStatusResponseWorkConfig) {
-	ws.Statuses = agent.WorkStatusResponseWorkConfigStatuses{
-		ClosedStatus:     getExistedStatusesOnly(ws.AllStatuses, []string{"Work Complete", "Completed", "Closed", "Done", "Fixed"}),
-		InProgressStatus: getExistedStatusesOnly(ws.AllStatuses, []string{"In Progress", "On Hold"}),
-		OpenStatus:       getExistedStatusesOnly(ws.AllStatuses, []string{"Open", "Work Required", "To Do", "Backlog"}),
-		InReviewStatus:   getExistedStatusesOnly(ws.AllStatuses, []string{"Awaiting Release", "Awaiting Validation", "In Review"}),
-		ReleasedStatus:   getExistedStatusesOnly(ws.AllStatuses, []string{"Released"}),
-		ReopenedStatus:   getExistedStatusesOnly(ws.AllStatuses, []string{"Reopened", "Rework"}),
+func appendStaticInfo(ws *agent.WorkStatusResponseWorkConfig, statuses []jiracommonapi.StatusDetail) {
+	ws.Statuses = agent.WorkStatusResponseWorkConfigStatuses{}
+	found := make(map[string]bool)
+	for _, status := range statuses {
+		if !found[status.Name] {
+			found[status.Name] = true
+			switch status.StatusCategory.Key {
+			case "new":
+				ws.Statuses.OpenStatus = append(ws.Statuses.OpenStatus, status.Name)
+			case "done":
+				ws.Statuses.ClosedStatus = append(ws.Statuses.ClosedStatus, status.Name)
+			case "indeterminate":
+				ws.Statuses.InProgressStatus = append(ws.Statuses.InProgressStatus, status.Name)
+			}
+		}
 	}
 	ws.TopLevelIssue = agent.WorkStatusResponseWorkConfigTopLevelIssue{
 		Name: "Epic",

--- a/integrations/pkg/jiracommon/workconfig_test.go
+++ b/integrations/pkg/jiracommon/workconfig_test.go
@@ -1,8 +1,12 @@
 package jiracommon
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"testing"
 
+	"github.com/pinpt/agent/integrations/pkg/jiracommonapi"
+	"github.com/pinpt/integration-sdk/agent"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,4 +22,18 @@ func TestGetExistedStatusesOnly(t *testing.T) {
 	actual := getExistedStatusesOnly(allValues, setValues)
 
 	assert.Equal(expected, actual)
+}
+
+func TestDefaultStatusStates(t *testing.T) {
+	assert := assert.New(t)
+	buf, err := ioutil.ReadFile("./testdata/status.json")
+	assert.NoError(err)
+	var statuses []jiracommonapi.StatusDetail
+	assert.NoError(json.Unmarshal(buf, &statuses))
+	assert.NotEmpty(statuses)
+	var wc agent.WorkStatusResponseWorkConfig
+	appendStaticInfo(&wc, statuses)
+	assert.Equal([]string{"Work Required", "Rework", "To Do", "Selected for Development", "Awaiting Validation", "Awaiting Release", "Work Complete", "In Testing", "Backlog", "Control Validation", "Evidence Needed", "Validate Evidence", "Acceptance"}, wc.Statuses.OpenStatus)
+	assert.Equal([]string{"In Progress", "In Review", "On Hold", "Gathering Evidence"}, wc.Statuses.InProgressStatus)
+	assert.Equal([]string{"Closed", "Done", "Ready for Promotion", "Validated", "Evidence Validated"}, wc.Statuses.ClosedStatus)
 }

--- a/integrations/pkg/jiracommonapi/status.go
+++ b/integrations/pkg/jiracommonapi/status.go
@@ -1,32 +1,5 @@
 package jiracommonapi
 
-func Status(qc QueryContext) (res []string, rerr error) {
-
-	objectPath := "status"
-
-	var rawStatuses []struct {
-		Name string `json:"name"`
-	}
-
-	err := qc.Request(objectPath, nil, &rawStatuses)
-	if err != nil {
-		rerr = err
-		return
-	}
-
-	m := make(map[string]bool)
-
-	for _, status := range rawStatuses {
-		m[status.Name] = true
-	}
-
-	for k := range m {
-		res = append(res, k)
-	}
-
-	return
-}
-
 type StatusDetail struct {
 	Name           string `json:"name"`
 	StatusCategory struct {
@@ -35,23 +8,21 @@ type StatusDetail struct {
 	} `json:"statusCategory"`
 }
 
-func StatusWithDetail(qc QueryContext) ([]StatusDetail, []string, error) {
+func StatusWithDetail(qc QueryContext) (_ []StatusDetail, names []string, _ error) {
 	objectPath := "status"
 
 	var detail []StatusDetail
-	m := make(map[string]bool)
-
 	err := qc.Request(objectPath, nil, &detail)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// we dedup names, but not the []StatusDetail array
+	m := map[string]bool{}
 	for _, status := range detail {
 		m[status.Name] = true
 	}
-
 	var res []string
-
 	for k := range m {
 		res = append(res, k)
 	}

--- a/integrations/pkg/jiracommonapi/status.go
+++ b/integrations/pkg/jiracommonapi/status.go
@@ -26,3 +26,35 @@ func Status(qc QueryContext) (res []string, rerr error) {
 
 	return
 }
+
+type StatusDetail struct {
+	Name           string `json:"name"`
+	StatusCategory struct {
+		Key  string `json:"key"`
+		Name string `json:"name"`
+	} `json:"statusCategory"`
+}
+
+func StatusWithDetail(qc QueryContext) ([]StatusDetail, []string, error) {
+	objectPath := "status"
+
+	var detail []StatusDetail
+	m := make(map[string]bool)
+
+	err := qc.Request(objectPath, nil, &detail)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, status := range detail {
+		m[status.Name] = true
+	}
+
+	var res []string
+
+	for k := range m {
+		res = append(res, k)
+	}
+
+	return detail, res, nil
+}


### PR DESCRIPTION
## Background

Currently, the agent hard codes the Jira default work config status mappings and we have a status mapping in the admin UI for mapping the statuses into the correct locations such as Open, In Progress, etc.  This requires a manual step before we can process data and its error prone.  Additionally, in the new release, we only care about open, in progress and closed.  In a subsequent release, we'll reintroduce a better way to map custom states to different states inside pinpoint.

## Change

This change uses the status category key field which can be one of: new, indeterminate and done.    We use this data to map each state to Open, In Progress and Closed status states automatically.
