### PR TITLE
set the correct default work done state for jira

### DIFF
--- a/integrations/pkg/jiracommon/workconfig.go
+++ b/integrations/pkg/jiracommon/workconfig.go
@@ -95,8 +95,8 @@ func appendStaticInfo(ws *agent.WorkStatusResponseWorkConfig, statuses []jiracom
 		Name: "Epic",
 		Type: "Issue",
 	}
-	ws.Resolutions.WorkDone = []string{"Completed"}
-	ws.Resolutions.NoWorkDone = []string{"Won't Do", "Invalid"}
+	ws.Resolutions.WorkDone = []string{"Done"}
+	ws.Resolutions.NoWorkDone = []string{} // NOTE: we don't use this currently so return empty for now until we do
 	ws.TypeRules = []agent.WorkStatusResponseWorkConfigTypeRules{
 		agent.WorkStatusResponseWorkConfigTypeRules{
 			IssueType: agent.WorkStatusResponseWorkConfigTypeRulesIssueTypeFeature,


### PR DESCRIPTION
- the default work done state was incorrect and should be "Done" based on the resolutions api
- since we're not using the non work done state currently, empty it out since the list wasn't complete and in the future we need to use the resolutions api from jira to get the complete list
