### PR TITLE
DINT-153 when sending events use different timeouts

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -423,7 +423,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:9069e08c248a5ba39d622f5eb604d1c109dd9dba12d381c4f1bed4d84a4fe54e"
+  digest = "1:0308e2a9b2b5579cdb705c08c77aa550c7e4d7b7d251d8d1c1c9dc23b8d5b055"
   name = "github.com/pinpt/go-common"
   packages = [
     "api",
@@ -447,8 +447,8 @@
     "upload",
   ]
   pruneopts = "T"
-  revision = "ed3cfbebcd7ef86a61361e5222b6780ddf8c4d70"
-  version = "v9.1.60"
+  revision = "a753e892a6051395b51058163e2a2d34ab5ca62c"
+  version = "v9.1.61"
 
 [[projects]]
   digest = "1:160af92c9d129fe26acd668a490d6dfe34fb73d9c9e2e77f13da7a6f427b1df0"

--- a/cmd/cmdenroll/enroll.go
+++ b/cmd/cmdenroll/enroll.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
-	pstrings "github.com/pinpt/go-common/strings"
-
 	"github.com/pinpt/agent/cmd/cmdvalidate"
+	"github.com/pinpt/agent/pkg/aevent"
 	"github.com/pinpt/agent/pkg/date"
 	"github.com/pinpt/agent/pkg/encrypt"
 	"github.com/pinpt/agent/pkg/sysinfo"
+	pstrings "github.com/pinpt/go-common/strings"
 
 	"github.com/pinpt/go-common/fileutil"
 
@@ -160,8 +160,9 @@ func (s *enroller) SendEvent(ctx context.Context) error {
 			"uuid": s.deviceID,
 		},
 	}
-
-	err := event.Publish(ctx, reqEvent, s.opts.Channel, "")
+	// wait longer on enroll requests
+	deadline := time.Now().Add(15 * time.Minute)
+	err := aevent.Publish(ctx, reqEvent, s.opts.Channel, "", event.WithDeadline(deadline))
 	if err != nil {
 		return fmt.Errorf("could not send enroll event, err: %v", err)
 	}

--- a/cmd/cmdexport/progress.go
+++ b/cmd/cmdexport/progress.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/pinpt/agent/pkg/aevent"
 	"github.com/pinpt/integration-sdk/agent"
 
 	"github.com/pinpt/go-common/event"
@@ -37,6 +38,5 @@ func (s *export) sendProgress(ctx context.Context, progressData []byte) error {
 			"uuid": s.EnrollConf.DeviceID,
 		},
 	}
-
-	return event.Publish(ctx, publishEvent, s.EnrollConf.Channel, s.EnrollConf.APIKey)
+	return aevent.Publish(ctx, publishEvent, s.EnrollConf.Channel, s.EnrollConf.APIKey)
 }

--- a/cmd/cmdintegration/integration.go
+++ b/cmd/cmdintegration/integration.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/pinpt/agent/cmd/cmdrunnorestarts/inconfig"
+	"github.com/pinpt/agent/pkg/aevent"
 	"github.com/pinpt/agent/pkg/date"
 	"github.com/pinpt/agent/pkg/expin"
 	"github.com/pinpt/agent/pkg/structmarshal"
@@ -314,5 +315,5 @@ func (s *Command) sendEvent(data datamodel.Model) error {
 			"job_id":      s.Opts.AgentConfig.Backend.ExportJobID,
 		},
 	}
-	return event.Publish(context.Background(), publishEvent, s.EnrollConf.Channel, s.EnrollConf.APIKey)
+	return aevent.Publish(context.Background(), publishEvent, s.EnrollConf.Channel, s.EnrollConf.APIKey)
 }

--- a/cmd/cmdrunnorestarts/exporter/events.go
+++ b/cmd/cmdrunnorestarts/exporter/events.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pinpt/agent/pkg/aevent"
 	"github.com/pinpt/agent/pkg/date"
 	"github.com/pinpt/go-common/event"
 	"github.com/pinpt/integration-sdk/agent"
@@ -101,5 +102,7 @@ func (s *Exporter) sendExportEvent(jobID string, data agent.ExportResponse) erro
 			"uuid": s.conf.DeviceID,
 		},
 	}
-	return event.Publish(context.Background(), publishEvent, s.conf.Channel, s.conf.APIKey)
+	// wait longer for export events, since if those are missed, processing will not continue normally
+	deadline := time.Now().Add(15 * time.Minute)
+	return aevent.Publish(context.Background(), publishEvent, s.conf.Channel, s.conf.APIKey, event.WithDeadline(deadline))
 }

--- a/cmd/cmdrunnorestarts/run.go
+++ b/cmd/cmdrunnorestarts/run.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/pinpt/agent/pkg/aevent"
 	"github.com/pinpt/agent/pkg/build"
 
 	"github.com/pinpt/agent/cmd/cmdintegration"
@@ -297,7 +298,7 @@ func (s *runner) sendEnabled(ctx context.Context) error {
 		},
 	}
 
-	err := event.Publish(ctx, publishEvent, s.conf.Channel, s.conf.APIKey)
+	err := aevent.Publish(ctx, publishEvent, s.conf.Channel, s.conf.APIKey)
 	if err != nil {
 		return err
 	}
@@ -413,7 +414,7 @@ func (s *runner) sendEvent(ctx context.Context, agentEvent datamodel.Model, jobI
 		Object:  agentEvent,
 		Headers: headers,
 	}
-	return event.Publish(ctx, e, s.conf.Channel, s.conf.APIKey)
+	return aevent.Publish(ctx, e, s.conf.Channel, s.conf.APIKey)
 }
 
 func (s *runner) sendEventAppendingDeviceInfo(ctx context.Context, event datamodel.Model, jobID string, extraHeaders map[string]string) error {

--- a/cmd/cmdrunnorestarts/subcommand/command.go
+++ b/cmd/cmdrunnorestarts/subcommand/command.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pinpt/agent/cmd/cmdintegration"
 	"github.com/pinpt/agent/cmd/cmdrunnorestarts/inconfig"
 	"github.com/pinpt/agent/cmd/cmdrunnorestarts/logsender"
+	"github.com/pinpt/agent/pkg/aevent"
 	"github.com/pinpt/agent/pkg/agentconf"
 	"github.com/pinpt/agent/pkg/date"
 	"github.com/pinpt/agent/pkg/deviceinfo"
@@ -273,7 +274,7 @@ func (c *Command) handlePanic(filename, cmdname string) error {
 			"job_id":      c.config.Backend.ExportJobID,
 		},
 	}
-	if err := event.Publish(context.Background(), publishEvent, c.agentConfig.Channel, c.agentConfig.APIKey); err != nil {
+	if err := aevent.Publish(context.Background(), publishEvent, c.agentConfig.Channel, c.agentConfig.APIKey); err != nil {
 		return fmt.Errorf("error sending agent.Crash to backend, err: %v", err)
 	}
 	return nil

--- a/pkg/aevent/event.go
+++ b/pkg/aevent/event.go
@@ -1,0 +1,21 @@
+// Package aevent contains agent default for publishing events
+package aevent
+
+import (
+	"context"
+	"time"
+
+	"github.com/pinpt/go-common/event"
+)
+
+const defaultPublishTimeout = 30 * time.Second
+
+func Publish(ctx context.Context, ev event.PublishEvent, channel string, apiKey string, options ...event.Option) error {
+
+	options2 := []event.Option{
+		event.WithDeadline(time.Now().Add(defaultPublishTimeout)),
+	}
+
+	options2 = append(options2, options...)
+	return event.Publish(ctx, ev, channel, apiKey, options2...)
+}


### PR DESCRIPTION
DINT-153 when sending events use long timeouts for enroll and export results, and short for everything else