### PR TITLE
DE-2193 Add issue type and issue priority model

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -413,8 +413,7 @@
   version = "2.0.0"
 
 [[projects]]
-  branch = "DE-2193"
-  digest = "1:4d5fed7522affeedc53ba6263ceb66a5a48d6289244e7928c917ad62ced777f1"
+  digest = "1:2a19a6eacea6c8a47890c828b60e51ba1316606a0e91b4deeb400b418481cd76"
   name = "github.com/pinpt/integration-sdk"
   packages = [
     ".",
@@ -426,7 +425,8 @@
     "work",
   ]
   pruneopts = "T"
-  revision = "43646fbe758b9ef47f764513ab6479aee0847536"
+  revision = "16491d04740339a61d97666738b0425d6ea9c62a"
+  version = "v0.0.793"
 
 [[projects]]
   branch = "slim"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -413,7 +413,8 @@
   version = "2.0.0"
 
 [[projects]]
-  digest = "1:9c830b9b5b374b8a38e23288330a10d914c41d7aa24fd4f0405266ed5e81c04f"
+  branch = "DE-2193"
+  digest = "1:4d5fed7522affeedc53ba6263ceb66a5a48d6289244e7928c917ad62ced777f1"
   name = "github.com/pinpt/integration-sdk"
   packages = [
     ".",
@@ -425,8 +426,7 @@
     "work",
   ]
   pruneopts = "T"
-  revision = "beffc65ae1e35d9fcb63d70ead692840d509ab59"
-  version = "v0.0.777"
+  revision = "43646fbe758b9ef47f764513ab6479aee0847536"
 
 [[projects]]
   branch = "slim"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,8 +35,8 @@
 
 [[constraint]]
   name = "github.com/pinpt/integration-sdk"
-  #version = "0"
-  branch = "DE-2193"
+  version = "0"
+  #branch = "DE-2193"
 
 [[constraint]]
   name = "github.com/denisbrodbeck/machineid"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,8 +35,8 @@
 
 [[constraint]]
   name = "github.com/pinpt/integration-sdk"
-  version = "0"
-  #branch = ""
+  #version = "0"
+  branch = "DE-2193"
 
 [[constraint]]
   name = "github.com/denisbrodbeck/machineid"

--- a/integrations/azure/api/work_config.go
+++ b/integrations/azure/api/work_config.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 
-	pstrings "github.com/pinpt/go-common/strings"
 	"github.com/pinpt/integration-sdk/agent"
 )
 
@@ -35,13 +34,6 @@ const workConfigInProgressStatus = workConfigStatus("InProgress")
 const workConfigProposedStatus = workConfigStatus("Proposed")
 const workConfigRemovedStatus = workConfigStatus("Removed")
 const workConfigResolvedStatus = workConfigStatus("Resolved")
-
-const typeBug = agent.WorkStatusResponseWorkConfigTypeRulesIssueTypeBug
-const typeFeature = agent.WorkStatusResponseWorkConfigTypeRulesIssueTypeFeature
-const typeOther = agent.WorkStatusResponseWorkConfigTypeRulesIssueTypeOther
-const typeEnhancement = agent.WorkStatusResponseWorkConfigTypeRulesIssueTypeEnhancement
-const predFieldType = agent.WorkStatusResponseWorkConfigTypeRulesPredicatesFieldType
-const predEquals = agent.WorkStatusResponseWorkConfigTypeRulesPredicatesOperatorEquals
 
 func stringEquals(str string, vals ...string) bool {
 	for _, v := range vals {
@@ -118,74 +110,74 @@ func (api *API) FetchWorkConfig() (*agent.WorkStatusResponseWorkConfig, error) {
 					// Assigned to states that represent a solution has been implemented, but are not yet verified
 					ws.Statuses.InReviewStatus = appendString(ws.Statuses.InReviewStatus, name)
 				}
-				ws.AllStatuses = appendString(ws.AllStatuses, name)
+				// ws.AllStatuses = appendString(ws.AllStatuses, name)
 			}
 
-			url2 := fmt.Sprintf(`%s/_apis/wit/workitemtypes/%s/fields`, project.RefID, r.ReferenceName)
-			var resres []resolutionRes
-			if err := api.getRequest(url2, stringmap{"$expand": "allowedValues"}, &resres); err != nil {
-				return nil, err
-			}
-			var reasons []string
-			var hasResolution bool
-			for _, g := range resres {
-				if len(g.AllowedValues) > 0 {
-					if g.ReferenceName == "Microsoft.VSTS.Common.ResolvedReason" {
-						for _, n := range g.AllowedValues {
-							ws.AllResolutions = appendString(ws.AllResolutions, itemStateName(n, r.Name))
-							hasResolution = true
-						}
-						continue
-					}
-					if g.ReferenceName == "System.Reason" {
-						for _, n := range g.AllowedValues {
-							reasons = appendString(reasons, itemStateName(n, r.Name))
-						}
-						continue
-					}
-				}
-			}
-			if !hasResolution {
-				for _, re := range reasons {
-					ws.AllResolutions = appendString(ws.AllResolutions, itemStateName(re, r.Name))
-				}
-			}
+			// url2 := fmt.Sprintf(`%s/_apis/wit/workitemtypes/%s/fields`, project.RefID, r.ReferenceName)
+			// var resres []resolutionRes
+			// if err := api.getRequest(url2, stringmap{"$expand": "allowedValues"}, &resres); err != nil {
+			// 	return nil, err
+			// }
+			// var reasons []string
+			// var hasResolution bool
+			// for _, g := range resres {
+			// 	if len(g.AllowedValues) > 0 {
+			// 		if g.ReferenceName == "Microsoft.VSTS.Common.ResolvedReason" {
+			// 			for _, n := range g.AllowedValues {
+			// 				ws.AllResolutions = appendString(ws.AllResolutions, itemStateName(n, r.Name))
+			// 				hasResolution = true
+			// 			}
+			// 			continue
+			// 		}
+			// 		if g.ReferenceName == "System.Reason" {
+			// 			for _, n := range g.AllowedValues {
+			// 				reasons = appendString(reasons, itemStateName(n, r.Name))
+			// 			}
+			// 			continue
+			// 		}
+			// 	}
+			// }
+			// if !hasResolution {
+			// 	for _, re := range reasons {
+			// 		ws.AllResolutions = appendString(ws.AllResolutions, itemStateName(re, r.Name))
+			// 	}
+			// }
 
-			predicate := agent.WorkStatusResponseWorkConfigTypeRulesPredicates{
-				Field:    predFieldType,
-				Operator: predEquals,
-				Value:    pstrings.Pointer(r.Name),
-			}
-			if stringEquals(r.ReferenceName,
-				"Microsoft.VSTS.WorkItemTypes.Issue",
-				"Microsoft.VSTS.WorkItemTypes.Bug",
-				"Issue", "Bug") {
-				ws.TypeRules = append(ws.TypeRules, agent.WorkStatusResponseWorkConfigTypeRules{
-					IssueType:  typeBug,
-					Predicates: []agent.WorkStatusResponseWorkConfigTypeRulesPredicates{predicate},
-				})
-			} else if stringEquals(r.ReferenceName,
-				"Microsoft.VSTS.WorkItemTypes.Task",
-				"Task") {
-				ws.TypeRules = append(ws.TypeRules, agent.WorkStatusResponseWorkConfigTypeRules{
-					IssueType:  typeEnhancement,
-					Predicates: []agent.WorkStatusResponseWorkConfigTypeRulesPredicates{predicate},
-				})
-			} else if stringEquals(r.ReferenceName,
-				"Microsoft.VSTS.WorkItemTypes.FeedbackRequest",
-				"Microsoft.VSTS.WorkItemTypes.Feature",
-				"Feature", "Feedback Request") {
-				ws.TypeRules = append(ws.TypeRules, agent.WorkStatusResponseWorkConfigTypeRules{
-					IssueType:  typeFeature,
-					Predicates: []agent.WorkStatusResponseWorkConfigTypeRulesPredicates{predicate},
-				})
-			} else {
-				ws.TypeRules = append(ws.TypeRules, agent.WorkStatusResponseWorkConfigTypeRules{
-					IssueType:  typeOther,
-					Predicates: []agent.WorkStatusResponseWorkConfigTypeRulesPredicates{predicate},
-				})
-			}
-			ws.Types = append(ws.Types, r.Name)
+			// predicate := agent.WorkStatusResponseWorkConfigTypeRulesPredicates{
+			// 	Field:    predFieldType,
+			// 	Operator: predEquals,
+			// 	Value:    pstrings.Pointer(r.Name),
+			// }
+			// if stringEquals(r.ReferenceName,
+			// 	"Microsoft.VSTS.WorkItemTypes.Issue",
+			// 	"Microsoft.VSTS.WorkItemTypes.Bug",
+			// 	"Issue", "Bug") {
+			// 	ws.TypeRules = append(ws.TypeRules, agent.WorkStatusResponseWorkConfigTypeRules{
+			// 		IssueType:  typeBug,
+			// 		Predicates: []agent.WorkStatusResponseWorkConfigTypeRulesPredicates{predicate},
+			// 	})
+			// } else if stringEquals(r.ReferenceName,
+			// 	"Microsoft.VSTS.WorkItemTypes.Task",
+			// 	"Task") {
+			// 	ws.TypeRules = append(ws.TypeRules, agent.WorkStatusResponseWorkConfigTypeRules{
+			// 		IssueType:  typeEnhancement,
+			// 		Predicates: []agent.WorkStatusResponseWorkConfigTypeRulesPredicates{predicate},
+			// 	})
+			// } else if stringEquals(r.ReferenceName,
+			// 	"Microsoft.VSTS.WorkItemTypes.FeedbackRequest",
+			// 	"Microsoft.VSTS.WorkItemTypes.Feature",
+			// 	"Feature", "Feedback Request") {
+			// 	ws.TypeRules = append(ws.TypeRules, agent.WorkStatusResponseWorkConfigTypeRules{
+			// 		IssueType:  typeFeature,
+			// 		Predicates: []agent.WorkStatusResponseWorkConfigTypeRulesPredicates{predicate},
+			// 	})
+			// } else {
+			// 	ws.TypeRules = append(ws.TypeRules, agent.WorkStatusResponseWorkConfigTypeRules{
+			// 		IssueType:  typeOther,
+			// 		Predicates: []agent.WorkStatusResponseWorkConfigTypeRulesPredicates{predicate},
+			// 	})
+			// }
+			// ws.Types = append(ws.Types, r.Name)
 		}
 	}
 	return ws, err
@@ -274,7 +266,7 @@ func (api *API) fetchColumnsForStatuses(projid string, ws *agent.WorkStatusRespo
 					break
 				}
 			}
-			ws.AllStatuses = appendString(ws.AllStatuses, e.Name)
+			// ws.AllStatuses = appendString(ws.AllStatuses, e.Name)
 		}
 	}
 }

--- a/integrations/jira-cloud/integration.go
+++ b/integrations/jira-cloud/integration.go
@@ -254,6 +254,30 @@ func (s *Integration) Export(ctx context.Context, config rpcdef.ExportConfig) (r
 		return
 	}
 
+	issueTypesSender, err := objsender.Root(s.agent, work.IssueTypeModelName.String())
+	err = s.common.IssueTypes(issueTypesSender)
+	if err != nil {
+		rerr = err
+		return
+	}
+	err = issueTypesSender.Done()
+	if err != nil {
+		rerr = err
+		return
+	}
+
+	issuePrioritiesSender, err := objsender.Root(s.agent, work.IssuePriorityModelName.String())
+	err = s.common.IssuePriorities(issuePrioritiesSender)
+	if err != nil {
+		rerr = err
+		return
+	}
+	err = issuePrioritiesSender.Done()
+	if err != nil {
+		rerr = err
+		return
+	}
+
 	err = s.common.ExportDone()
 	if err != nil {
 		rerr = err

--- a/integrations/jira-cloud/onboarding.go
+++ b/integrations/jira-cloud/onboarding.go
@@ -64,5 +64,5 @@ func (s *Integration) onboardWorkConfig(ctx context.Context, config rpcdef.Expor
 		return res, err
 	}
 
-	return jiracommon.GetWorkConfig(s.qc.Common(), true, s.UseOAuth)
+	return jiracommon.GetWorkConfig(s.qc.Common())
 }

--- a/integrations/jira-hosted/integration.go
+++ b/integrations/jira-hosted/integration.go
@@ -207,6 +207,30 @@ func (s *Integration) Export(ctx context.Context, config rpcdef.ExportConfig) (r
 		return
 	}
 
+	issueTypesSender, err := objsender.Root(s.agent, work.IssueTypeModelName.String())
+	err = s.common.IssueTypes(issueTypesSender)
+	if err != nil {
+		rerr = err
+		return
+	}
+	err = issueTypesSender.Done()
+	if err != nil {
+		rerr = err
+		return
+	}
+
+	issuePrioritiesSender, err := objsender.Root(s.agent, work.IssuePriorityModelName.String())
+	err = s.common.IssuePriorities(issuePrioritiesSender)
+	if err != nil {
+		rerr = err
+		return
+	}
+	err = issuePrioritiesSender.Done()
+	if err != nil {
+		rerr = err
+		return
+	}
+
 	err = s.common.ExportDone()
 	if err != nil {
 		rerr = err

--- a/integrations/jira-hosted/onboarding.go
+++ b/integrations/jira-hosted/onboarding.go
@@ -47,5 +47,5 @@ func (s *Integration) onboardWorkConfig(ctx context.Context, config rpcdef.Expor
 		return res, err
 	}
 
-	return jiracommon.GetWorkConfig(s.qc.Common(), false, false)
+	return jiracommon.GetWorkConfig(s.qc.Common())
 }

--- a/integrations/pkg/jiracommon/workconfig.go
+++ b/integrations/pkg/jiracommon/workconfig.go
@@ -3,76 +3,24 @@ package jiracommon
 import (
 	"github.com/pinpt/agent/integrations/pkg/jiracommonapi"
 	"github.com/pinpt/agent/rpcdef"
-	pstrings "github.com/pinpt/go-common/strings"
 	"github.com/pinpt/integration-sdk/agent"
 )
 
-func GetWorkConfig(qc jiracommonapi.QueryContext, isCloud bool, usesOauth bool) (res rpcdef.OnboardExportResult, _ error) {
+// GetWorkConfig will return the default jira work config
+func GetWorkConfig(qc jiracommonapi.QueryContext) (res rpcdef.OnboardExportResult, _ error) {
 
 	var ws agent.WorkStatusResponseWorkConfig
 
-	priorities, err := jiracommonapi.Priorities(qc)
+	statusDetail, _, err := jiracommonapi.StatusWithDetail(qc)
 	if err != nil {
 		res.Error = err
 		return
 	}
-	ws.Priorities = priorities
-
-	if isCloud && !usesOauth {
-		// This doesn't work with hosted
-		// This doesn't work with cloud with oauth, server response: "OAuth 2.0 is not enabled for this method."
-		labels, err := jiracommonapi.Labels(qc)
-		if err != nil {
-			res.Error = err
-			return
-		}
-		ws.Labels = labels
-	}
-
-	issueTypes, err := jiracommonapi.IssueTypes(qc)
-	if err != nil {
-		res.Error = err
-		return
-	}
-	ws.Types = issueTypes
-
-	statusDetail, allStatus, err := jiracommonapi.StatusWithDetail(qc)
-	if err != nil {
-		res.Error = err
-		return
-	}
-	ws.AllStatuses = allStatus
-
-	resolutions, err := jiracommonapi.Resolution(qc)
-	if err != nil {
-		res.Error = err
-		return
-	}
-
-	ws.AllResolutions = resolutions
 
 	appendStaticInfo(&ws, statusDetail)
 
 	res.Data = ws.ToMap()
 	return
-}
-
-func getExistedStatusesOnly(allstatus, optns []string) []string {
-
-	var res []string
-	mAll := make(map[string]bool)
-
-	for _, v := range allstatus {
-		mAll[v] = true
-	}
-
-	for _, v := range optns {
-		if _, ok := mAll[v]; ok {
-			res = append(res, v)
-		}
-	}
-
-	return res
 }
 
 func appendStaticInfo(ws *agent.WorkStatusResponseWorkConfig, statuses []jiracommonapi.StatusDetail) {
@@ -94,39 +42,5 @@ func appendStaticInfo(ws *agent.WorkStatusResponseWorkConfig, statuses []jiracom
 	ws.TopLevelIssue = agent.WorkStatusResponseWorkConfigTopLevelIssue{
 		Name: "Epic",
 		Type: "Issue",
-	}
-	ws.Resolutions.WorkDone = []string{"Done"}
-	ws.Resolutions.NoWorkDone = []string{} // NOTE: we don't use this currently so return empty for now until we do
-	ws.TypeRules = []agent.WorkStatusResponseWorkConfigTypeRules{
-		agent.WorkStatusResponseWorkConfigTypeRules{
-			IssueType: agent.WorkStatusResponseWorkConfigTypeRulesIssueTypeFeature,
-			Predicates: []agent.WorkStatusResponseWorkConfigTypeRulesPredicates{
-				agent.WorkStatusResponseWorkConfigTypeRulesPredicates{
-					Field:    agent.WorkStatusResponseWorkConfigTypeRulesPredicatesFieldType,
-					Operator: agent.WorkStatusResponseWorkConfigTypeRulesPredicatesOperatorEquals,
-					Value:    pstrings.Pointer("Feature"),
-				},
-			},
-		},
-		agent.WorkStatusResponseWorkConfigTypeRules{
-			IssueType: agent.WorkStatusResponseWorkConfigTypeRulesIssueTypeEnhancement,
-			Predicates: []agent.WorkStatusResponseWorkConfigTypeRulesPredicates{
-				agent.WorkStatusResponseWorkConfigTypeRulesPredicates{
-					Field:    agent.WorkStatusResponseWorkConfigTypeRulesPredicatesFieldType,
-					Operator: agent.WorkStatusResponseWorkConfigTypeRulesPredicatesOperatorEquals,
-					Value:    pstrings.Pointer("Enhancement"),
-				},
-			},
-		},
-		agent.WorkStatusResponseWorkConfigTypeRules{
-			IssueType: agent.WorkStatusResponseWorkConfigTypeRulesIssueTypeBug,
-			Predicates: []agent.WorkStatusResponseWorkConfigTypeRulesPredicates{
-				agent.WorkStatusResponseWorkConfigTypeRulesPredicates{
-					Field:    agent.WorkStatusResponseWorkConfigTypeRulesPredicatesFieldType,
-					Operator: agent.WorkStatusResponseWorkConfigTypeRulesPredicatesOperatorEquals,
-					Value:    pstrings.Pointer("Bug"),
-				},
-			},
-		},
 	}
 }

--- a/integrations/pkg/jiracommon/workconfig_test.go
+++ b/integrations/pkg/jiracommon/workconfig_test.go
@@ -10,20 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetExistedStatusesOnly(t *testing.T) {
-
-	assert := assert.New(t)
-
-	allValues := []string{"Selected for Development", "Backlog", "Validated", "Evidence Needed", "Evidence Validated", "Done", "Ready for Promotion", "Work Required", "Rework", "Closed", "To Do", "Awaiting Release", "In Testing", "Control Validation", "In Progress", "Awaiting Validation", "Work Complete", "In Review", "Validate Evidence", "On Hold", "Gathering Evidence"}
-	setValues := []string{"Work Complete", "Completed", "Closed", "Done", "Fixed"}
-
-	expected := []string{"Work Complete", "Closed", "Done"}
-
-	actual := getExistedStatusesOnly(allValues, setValues)
-
-	assert.Equal(expected, actual)
-}
-
 func TestDefaultStatusStates(t *testing.T) {
 	assert := assert.New(t)
 	buf, err := ioutil.ReadFile("./testdata/status.json")

--- a/integrations/pkg/jiracommonapi/common.go
+++ b/integrations/pkg/jiracommonapi/common.go
@@ -1,6 +1,8 @@
 package jiracommonapi
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/pinpt/agent/pkg/ids"
@@ -27,6 +29,11 @@ func (s QueryContext) ProjectURL(projectKey string) string {
 
 func (s QueryContext) IssueURL(issueKey string) string {
 	return pstrings.JoinURL(s.WebsiteURL, "browse", issueKey)
+}
+
+func (s QueryContext) IssueCommentURL(issueKey string, commentID string) string {
+	// looks like: https://pinpt-hq.atlassian.net/browse/DE-2194?focusedCommentId=17692&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17692
+	return pstrings.JoinURL(s.WebsiteURL, "browse", issueKey+fmt.Sprintf("?focusedCommentId=%s&page=com.atlassian.jira.plugin.system.issuetabpanels%%3Acomment-tabpanel#comment-%s", commentID, commentID))
 }
 
 func (s QueryContext) ProjectID(refID string) string {

--- a/integrations/pkg/jiracommonapi/issue_comments.go
+++ b/integrations/pkg/jiracommonapi/issue_comments.go
@@ -11,6 +11,7 @@ func IssueComments(
 	qc QueryContext,
 	project Project,
 	issueRefID string,
+	issueKey string,
 	paginationParams url.Values) (pi PageInfo, resIssueComments []*work.IssueComment, rerr error) {
 
 	objectPath := "issue/" + issueRefID + "/comment"
@@ -81,7 +82,7 @@ func IssueComments(
 		item.UserRefID = authorID
 		item.Body = adjustRenderedHTML(qc.WebsiteURL, data.RenderedBody)
 
-		item.URL = data.Self
+		item.URL = qc.IssueCommentURL(issueKey, data.ID)
 
 		resIssueComments = append(resIssueComments, item)
 	}

--- a/integrations/pkg/jiracommonapi/issues.go
+++ b/integrations/pkg/jiracommonapi/issues.go
@@ -85,9 +85,11 @@ type issueFields struct {
 	Created  string `json:"created"`
 	Updated  string `json:"updated"`
 	Priority struct {
+		ID   string `json:"id"`
 		Name string `json:"name"`
 	} `json:"priority"`
 	IssueType struct {
+		ID   string `json:"id"`
 		Name string `json:"name"`
 	} `json:"issuetype"`
 	Status struct {
@@ -323,7 +325,9 @@ func convertIssue(qc QueryContext, data issueSource, fieldByID map[string]Custom
 	date.ConvertToModel(updated, &item.UpdatedDate)
 
 	item.Priority = fields.Priority.Name
+	item.PriorityID = work.NewIssuePriorityID(qc.CustomerID, "jira", fields.Priority.ID)
 	item.Type = fields.IssueType.Name
+	item.TypeID = work.NewIssueTypeID(qc.CustomerID, "jira", fields.IssueType.ID)
 	item.Status = fields.Status.Name
 	item.Resolution = fields.Resolution.Name
 

--- a/integrations/pkg/jiracommonapi/issuetype.go
+++ b/integrations/pkg/jiracommonapi/issuetype.go
@@ -1,11 +1,41 @@
 package jiracommonapi
 
-func IssueTypes(qc QueryContext) (res []string, rerr error) {
+import "github.com/pinpt/integration-sdk/work"
+
+func getMappedIssueType(name string, subtask bool) work.IssueTypeMappedType {
+	if subtask {
+		// any subtask will have this flag set
+		return work.IssueTypeMappedTypeSubtask
+	}
+	// map out of the box jira types that are known
+	switch name {
+	case "Story":
+		return work.IssueTypeMappedTypeStory
+	case "Improvement", "Enhancement":
+		return work.IssueTypeMappedTypeEnhancement
+	case "Epic":
+		return work.IssueTypeMappedTypeEpic
+	case "New Feature":
+		return work.IssueTypeMappedTypeFeature
+	case "Bug":
+		return work.IssueTypeMappedTypeBug
+	case "Task":
+		return work.IssueTypeMappedTypeTask
+	}
+	// otherwise this is a custom type which can be mapped from the app side by the user
+	return work.IssueTypeMappedTypeUnknown
+}
+
+func IssueTypes(qc QueryContext) (res []work.IssueType, rerr error) {
 
 	objectPath := "issuetype"
 
 	var issueTypes []struct {
-		Name string `json:"name"`
+		ID          string `json:"id"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Icon        string `json:"iconUrl"`
+		Subtask     bool   `json:"subtask"`
 	}
 
 	err := qc.Req.Get(objectPath, nil, &issueTypes)
@@ -14,14 +44,22 @@ func IssueTypes(qc QueryContext) (res []string, rerr error) {
 		return
 	}
 
-	m := make(map[string]bool)
+	found := make(map[string]bool)
 
-	for _, typ := range issueTypes {
-		m[typ.Name] = true
-	}
-
-	for k := range m {
-		res = append(res, k)
+	for _, val := range issueTypes {
+		if !found[val.Name] {
+			found[val.Name] = true // can have duplicates scoped by project id which we might want to support in the future
+			res = append(res, work.IssueType{
+				ID:          work.NewIssueTypeID(qc.CustomerID, "jira", val.ID),
+				CustomerID:  qc.CustomerID,
+				Name:        val.Name,
+				Description: &val.Description,
+				IconURL:     &val.Icon,
+				MappedType:  getMappedIssueType(val.Name, val.Subtask),
+				RefType:     "jira",
+				RefID:       val.ID,
+			})
+		}
 	}
 
 	return

--- a/integrations/pkg/jiracommonapi/priorities.go
+++ b/integrations/pkg/jiracommonapi/priorities.go
@@ -32,7 +32,7 @@ func Priorities(qc QueryContext) (res []work.IssuePriority, rerr error) {
 			Description: &priority.Description,
 			IconURL:     &priority.Icon,
 			Color:       &priority.Color,
-			Order:       int64(order),
+			Order:       int64(1 + order), // we use 0 for no order so offset by one to make the last != 0
 			RefType:     "jira",
 			RefID:       priority.ID,
 		})

--- a/integrations/pkg/jiracommonapi/priorities.go
+++ b/integrations/pkg/jiracommonapi/priorities.go
@@ -1,11 +1,17 @@
 package jiracommonapi
 
-func Priorities(qc QueryContext) (res []string, rerr error) {
+import "github.com/pinpt/integration-sdk/work"
+
+func Priorities(qc QueryContext) (res []work.IssuePriority, rerr error) {
 
 	objectPath := "priority"
 
 	var rawPriorities []struct {
-		Name string `json:"name"`
+		ID          string `json:"id"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Color       string `json:"statusColor"`
+		Icon        string `json:"iconUrl"`
 	}
 
 	err := qc.Req.Get(objectPath, nil, &rawPriorities)
@@ -14,8 +20,22 @@ func Priorities(qc QueryContext) (res []string, rerr error) {
 		return
 	}
 
-	for _, priority := range rawPriorities {
-		res = append(res, priority.Name)
+	// the result comes back in priority order from HIGH (0) to LOW (length-1)
+	// so we iterate backwards to make the highest first and the lowest last
+
+	for order := len(rawPriorities) - 1; order >= 0; order-- {
+		priority := rawPriorities[order]
+		res = append(res, work.IssuePriority{
+			ID:          work.NewIssuePriorityID(qc.CustomerID, "jira", priority.ID),
+			CustomerID:  qc.CustomerID,
+			Name:        priority.Name,
+			Description: &priority.Description,
+			IconURL:     &priority.Icon,
+			Color:       &priority.Color,
+			Order:       int64(order),
+			RefType:     "jira",
+			RefID:       priority.ID,
+		})
 	}
 
 	return


### PR DESCRIPTION
Added 2 new models (work.IssueType and work.IssuePriority) which are first class objects for issue type and priority.  Also remove unused fields in WorkConfig

This commit also resolves DI-217 (issue comment url is wrong)

NOTE: Before this merges, we need to release the datamodel from this PR: 
 https://github.com/pinpt/datamodel/pull/407

one thing i couldn’t figure out was how to
only send if not changed so need to
update that too

needs backport to azure