### PR TITLE
TIGR-37 add commit identifier

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -348,6 +348,7 @@
     "event/action",
     "eventing",
     "fileutil",
+    "graphql",
     "hash",
     "httpdefaults",
     "io",
@@ -373,7 +374,8 @@
   version = "2.0.0"
 
 [[projects]]
-  digest = "1:b499b5a29fd0f72f40480bc78d5495861a4bf65e938e8f720243a72118bee13c"
+  branch = "TIGR-37"
+  digest = "1:0defde78e548359785c6d4096e2faa8c9bcb585b00f30bccdb575aad2787fa4a"
   name = "github.com/pinpt/integration-sdk"
   packages = [
     ".",
@@ -385,8 +387,7 @@
     "work",
   ]
   pruneopts = "T"
-  revision = "64db56c95d1d6ca6400d0cde59aea9c699b3449f"
-  version = "v0.0.808"
+  revision = "96e41cbb49b027abc4cf0cd2839b3278d2cf2f8b"
 
 [[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -348,7 +348,6 @@
     "event/action",
     "eventing",
     "fileutil",
-    "graphql",
     "hash",
     "httpdefaults",
     "io",
@@ -374,8 +373,7 @@
   version = "2.0.0"
 
 [[projects]]
-  branch = "TIGR-37"
-  digest = "1:0defde78e548359785c6d4096e2faa8c9bcb585b00f30bccdb575aad2787fa4a"
+  digest = "1:8a1d1814b9bb33c25d0b434acc6e00a3e3306a9f09a0565d8262fec3dfcce6cc"
   name = "github.com/pinpt/integration-sdk"
   packages = [
     ".",
@@ -387,7 +385,8 @@
     "work",
   ]
   pruneopts = "T"
-  revision = "96e41cbb49b027abc4cf0cd2839b3278d2cf2f8b"
+  revision = "890232723112138b767d6f6a8f746c0ca482f388"
+  version = "v0.0.815"
 
 [[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,8 +35,8 @@
 
 [[constraint]]
   name = "github.com/pinpt/integration-sdk"
-  #version = "0"
-  branch = "TIGR-37"
+  version = "0"
+  #branch = "TIGR-37"
 
 [[constraint]]
   name = "github.com/denisbrodbeck/machineid"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,8 +35,8 @@
 
 [[constraint]]
   name = "github.com/pinpt/integration-sdk"
-  version = "0"
-  #branch = "DE-2193"
+  #version = "0"
+  branch = "TIGR-37"
 
 [[constraint]]
   name = "github.com/denisbrodbeck/machineid"

--- a/slimrippy/exportrepo/exportrepo.go
+++ b/slimrippy/exportrepo/exportrepo.go
@@ -387,12 +387,15 @@ func (s *Export) commitIDs(shas []string) (res []string) {
 
 const lpCommit = "commit"
 
+// CommitIdentifier creates the unique identifier as a combination of the unique repo name and a short sha for display purposes
+func CommitIdentifier(repoUniqueName string, sha string) string {
+	return repoUniqueName + "#" + sha[0:7]
+}
+
 func (s *Export) commit(commit slimrippy.Commit) error {
 	sessions := s.opts.Sessions
 
 	writeCommit := func(obj sourcecode.Commit) error {
-		// create the unique identifier as a combination of the unique repo name and a short sha for display purposes
-		obj.Identifier = s.opts.UniqueName + "#" + obj.Sha[0:7]
 		return sessions.Write(s.sessions.Commit, []map[string]interface{}{
 			obj.ToMap(),
 		})
@@ -426,6 +429,7 @@ func (s *Export) commit(commit slimrippy.Commit) error {
 		URL:            commitURL(s.opts.CommitURLTemplate, commit.SHA),
 		AuthorRefID:    ids.CodeCommitEmail(customerID, commit.Authored.Email),
 		CommitterRefID: ids.CodeCommitEmail(customerID, commit.Committed.Email),
+		Identifier:     CommitIdentifier(s.opts.UniqueName, commit.SHA),
 	}
 
 	date.ConvertToModel(commit.Committed.Date, &c.CreatedDate)

--- a/slimrippy/exportrepo/exportrepo.go
+++ b/slimrippy/exportrepo/exportrepo.go
@@ -391,6 +391,8 @@ func (s *Export) commit(commit slimrippy.Commit) error {
 	sessions := s.opts.Sessions
 
 	writeCommit := func(obj sourcecode.Commit) error {
+		// create the unique identifier as a combination of the unique repo name and a short sha for display purposes
+		obj.Identifier = s.opts.UniqueName + "#" + obj.Sha[0:7]
 		return sessions.Write(s.sessions.Commit, []map[string]interface{}{
 			obj.ToMap(),
 		})

--- a/slimrippy/exportrepo/tests/all_test.go
+++ b/slimrippy/exportrepo/tests/all_test.go
@@ -31,6 +31,12 @@ func strp(v string) *string {
 func TestExportRepoBasic1(t *testing.T) {
 	want := map[string]interface{}{}
 
+	repoName := "basic1"
+
+	commitIdentifier := func(sha string) string {
+		return exportrepo.CommitIdentifier(repoName, sha)
+	}
+
 	want["sourcecode.Commit"] = []sourcecode.Commit{
 		{
 			AuthorRefID:    "562d0daa5e0b4946",
@@ -43,6 +49,7 @@ func TestExportRepoBasic1(t *testing.T) {
 			RepoID:         "r1",
 			Sha:            "33e223d1fd8393dc98596727d370e51e7b3b7fba",
 			URL:            "/commit/33e223d1fd8393dc98596727d370e51e7b3b7fba",
+			Identifier:     commitIdentifier("33e223d1fd8393dc98596727d370e51e7b3b7fba"),
 		},
 		{
 			AuthorRefID:    "562d0daa5e0b4946",
@@ -55,6 +62,7 @@ func TestExportRepoBasic1(t *testing.T) {
 			RepoID:         "r1",
 			Sha:            "9b39087654af70197f68d0b3d196a4a20d987cd6",
 			URL:            "/commit/9b39087654af70197f68d0b3d196a4a20d987cd6",
+			Identifier:     commitIdentifier("9b39087654af70197f68d0b3d196a4a20d987cd6"),
 		},
 	}
 
@@ -114,12 +122,19 @@ func TestExportRepoBasic1(t *testing.T) {
 
 	opts := Opts{}
 	opts.T = t
-	opts.RepoName = "basic1"
+	opts.RepoName = repoName
 	opts.Want = want
 	Run(opts)
 }
 
 func TestExportRepoPullRequestBranches(t *testing.T) {
+
+	repoName := "basic1"
+
+	commitIdentifier := func(sha string) string {
+		return exportrepo.CommitIdentifier(repoName, sha)
+	}
+
 	pr1 := exportrepo.PR{
 		ID:            "prid",
 		RefID:         "prrefid",
@@ -144,6 +159,7 @@ func TestExportRepoPullRequestBranches(t *testing.T) {
 			RepoID:         "r1",
 			Sha:            "33e223d1fd8393dc98596727d370e51e7b3b7fba",
 			URL:            "/commit/33e223d1fd8393dc98596727d370e51e7b3b7fba",
+			Identifier:     commitIdentifier("33e223d1fd8393dc98596727d370e51e7b3b7fba"),
 		},
 		{
 			AuthorRefID:    "562d0daa5e0b4946",
@@ -156,6 +172,7 @@ func TestExportRepoPullRequestBranches(t *testing.T) {
 			RepoID:         "r1",
 			Sha:            "9b39087654af70197f68d0b3d196a4a20d987cd6",
 			URL:            "/commit/9b39087654af70197f68d0b3d196a4a20d987cd6",
+			Identifier:     commitIdentifier("9b39087654af70197f68d0b3d196a4a20d987cd6"),
 		},
 	}
 
@@ -237,7 +254,7 @@ func TestExportRepoPullRequestBranches(t *testing.T) {
 
 	opts := Opts{}
 	opts.T = t
-	opts.RepoName = "basic1"
+	opts.RepoName = repoName
 	opts.Want = want
 	opts.Export = exportOpts
 	Run(opts)
@@ -245,6 +262,13 @@ func TestExportRepoPullRequestBranches(t *testing.T) {
 
 // The cloned repo here has remote set, make sure we don't export the remote branches of cloned repo
 func TestExportRemoteHasRemote(t *testing.T) {
+
+	repoName := "remote-has-remote"
+
+	commitIdentifier := func(sha string) string {
+		return exportrepo.CommitIdentifier(repoName, sha)
+	}
+
 	want := map[string]interface{}{}
 
 	want["sourcecode.Commit"] = []sourcecode.Commit{
@@ -259,6 +283,7 @@ func TestExportRemoteHasRemote(t *testing.T) {
 			RepoID:         "r1",
 			Sha:            "63d8e58c077905aa51538184feb66852f02e2856",
 			URL:            "/commit/63d8e58c077905aa51538184feb66852f02e2856",
+			Identifier:     commitIdentifier("63d8e58c077905aa51538184feb66852f02e2856"),
 		},
 		{
 			AuthorRefID:    "562d0daa5e0b4946",
@@ -271,6 +296,7 @@ func TestExportRemoteHasRemote(t *testing.T) {
 			RepoID:         "r1",
 			Sha:            "0557506be087faa32994bf07ef7a559cf64123c9",
 			URL:            "/commit/0557506be087faa32994bf07ef7a559cf64123c9",
+			Identifier:     commitIdentifier("0557506be087faa32994bf07ef7a559cf64123c9"),
 		},
 	}
 
@@ -310,12 +336,19 @@ func TestExportRemoteHasRemote(t *testing.T) {
 
 	opts := Opts{}
 	opts.T = t
-	opts.RepoName = "remote-has-remote"
+	opts.RepoName = repoName
 	opts.Want = want
 	Run(opts)
 }
 
 func TestExportRepoIncremental1(t *testing.T) {
+
+	repoName := "basic-incremental1"
+
+	commitIdentifier := func(sha string) string {
+		return exportrepo.CommitIdentifier(repoName, sha)
+	}
+
 	opts := Opts{}
 	opts.T = t
 	opts.RepoName = "basic1"
@@ -336,6 +369,7 @@ func TestExportRepoIncremental1(t *testing.T) {
 			RepoID:         "r1",
 			Sha:            "63b0ac79015985fe248ba0ea3e34fa464fae1b7a",
 			URL:            "/commit/63b0ac79015985fe248ba0ea3e34fa464fae1b7a",
+			Identifier:     commitIdentifier("63b0ac79015985fe248ba0ea3e34fa464fae1b7a"),
 		},
 	}
 
@@ -400,7 +434,7 @@ func TestExportRepoIncremental1(t *testing.T) {
 
 	opts = Opts{}
 	opts.T = t
-	opts.RepoName = "basic-incremental1"
+	opts.RepoName = repoName
 	opts.Dirs = dirs
 	opts.Want = want
 
@@ -408,6 +442,13 @@ func TestExportRepoIncremental1(t *testing.T) {
 }
 
 func TestExportRepoIncrementalPullRequests1(t *testing.T) {
+
+	repoName := "basic1"
+
+	commitIdentifier := func(sha string) string {
+		return exportrepo.CommitIdentifier(repoName, sha)
+	}
+
 	opts := Opts{}
 	opts.T = t
 	opts.RepoName = "basic1"
@@ -439,6 +480,7 @@ func TestExportRepoIncrementalPullRequests1(t *testing.T) {
 			RepoID:         "r1",
 			Sha:            "63b0ac79015985fe248ba0ea3e34fa464fae1b7a",
 			URL:            "/commit/63b0ac79015985fe248ba0ea3e34fa464fae1b7a",
+			Identifier:     commitIdentifier("63b0ac79015985fe248ba0ea3e34fa464fae1b7a"),
 		},
 	}
 
@@ -526,6 +568,7 @@ func TestExportRepoIncrementalPullRequests1(t *testing.T) {
 	opts = Opts{}
 	opts.T = t
 	opts.RepoName = "basic-incremental1"
+	opts.RepoUniqueName = repoName
 	opts.Dirs = dirs
 	opts.Want = want
 	opts.Export = exportOpts

--- a/slimrippy/exportrepo/tests/base.go
+++ b/slimrippy/exportrepo/tests/base.go
@@ -24,10 +24,11 @@ import (
 )
 
 type Opts struct {
-	T        *testing.T
-	RepoName string
-	Export   *exportrepo.Opts
-	Want     map[string]interface{}
+	T              *testing.T
+	RepoName       string
+	RepoUniqueName string // if not set same as reponame used to get the zip file
+	Export         *exportrepo.Opts
+	Want           map[string]interface{}
 
 	IncrementalStep1 bool
 	Dirs             *TestDirs
@@ -75,6 +76,9 @@ func Run(opts Opts) *TestDirs {
 	eo.Sessions = sessions
 	eo.RepoID = "r1"
 	eo.UniqueName = repoName
+	if opts.RepoUniqueName != "" {
+		eo.UniqueName = opts.RepoUniqueName
+	}
 	eo.CustomerID = "c1"
 	eo.LastProcessed = lastProcessed
 	eo.CommitURLTemplate = "/commit/@@@sha@@@"


### PR DESCRIPTION
this PR adds the sourcecode.Commit identifier field as a short way to display a commit.

don't merge this PR until we can release the datamodel and update the Gopkg.lock with new release