### PR TITLE
PROD-944 Added temporary oauth1 support for jira-hosted

### DIFF
--- a/integrations/bitbucket/integration.go
+++ b/integrations/bitbucket/integration.go
@@ -164,10 +164,13 @@ func (s *Integration) initWithConfig(config rpcdef.ExportConfig) error {
 		s.oauth = oauth
 	}
 
-	s.clientManager = reqstats.New(reqstats.Opts{
+	s.clientManager, err = reqstats.New(reqstats.Opts{
 		Logger:                s.logger,
 		TLSInsecureSkipVerify: s.config.InsecureSkipVerify,
 	})
+	if err != nil {
+		return err
+	}
 
 	{
 		opts := api.RequesterOpts{}

--- a/integrations/github/api/webhook_registration_test.go
+++ b/integrations/github/api/webhook_registration_test.go
@@ -124,13 +124,16 @@ func TestWebhookCreateIfNotExists(t *testing.T) {
 		Name: "test",
 	})
 
+	rm, err := reqstats.New(reqstats.Opts{
+		Logger:                logger,
+		TLSInsecureSkipVerify: true,
+	})
+	assert.NoError(err)
+
 	qc := QueryContext{
 		APIURL3: server.URL,
 		Logger:  logger,
-		Clients: reqstats.New(reqstats.Opts{
-			Logger:                logger,
-			TLSInsecureSkipVerify: true,
-		}).Clients,
+		Clients: rm.Clients,
 	}
 
 	// don't do anything
@@ -139,7 +142,7 @@ func TestWebhookCreateIfNotExists(t *testing.T) {
 		NameWithOwner: "pinpt/test",
 	}
 
-	err := WebhookCreateIfNotExists(qc, testRepo, "https://test.example.com", []string{"wh1"}, WebhookReplaceOlderThan)
+	err = WebhookCreateIfNotExists(qc, testRepo, "https://test.example.com", []string{"wh1"}, WebhookReplaceOlderThan)
 	assert.NoError(err)
 
 	// no permissions

--- a/integrations/github/integration.go
+++ b/integrations/github/integration.go
@@ -219,10 +219,13 @@ func (s *Integration) initWithConfig(exportConfig rpcdef.ExportConfig) error {
 	s.qc.APIURL = s.config.APIURL
 	s.qc.APIURL3 = s.config.APIURL3
 	s.qc.AuthToken = s.config.Token
-	s.clientManager = reqstats.New(reqstats.Opts{
+	s.clientManager, err = reqstats.New(reqstats.Opts{
 		Logger:                s.logger,
 		TLSInsecureSkipVerify: s.config.TLSInsecureSkipVerify,
 	})
+	if err != nil {
+		return err
+	}
 	s.clients = s.clientManager.Clients
 	s.qc.Clients = s.clients
 	s.qc.Request = s.makeRequest

--- a/integrations/jira-cloud/integration.go
+++ b/integrations/jira-cloud/integration.go
@@ -97,10 +97,13 @@ func (s *Integration) initWithConfig(config rpcdef.ExportConfig, retryRequests b
 	}
 	s.UseOAuth = config.UseOAuth
 
-	s.clientManager = reqstats.New(reqstats.Opts{
+	s.clientManager, err = reqstats.New(reqstats.Opts{
 		Logger:                s.logger,
 		TLSInsecureSkipVerify: false,
 	})
+	if err != nil {
+		return err
+	}
 	s.clients = s.clientManager.Clients
 
 	var oauth *oauthtoken.Manager

--- a/integrations/jira-hosted/integration.go
+++ b/integrations/jira-hosted/integration.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/pinpt/agent/pkg/reqstats"
 	"github.com/pinpt/agent/pkg/structmarshal"
@@ -86,10 +88,15 @@ func (s *Integration) initWithConfig(config rpcdef.ExportConfig, retryRequests b
 	s.qc.CustomerID = config.Pinpoint.CustomerID
 	s.qc.Logger = s.logger
 
+	useOAuth1, err := strconv.ParseBool(os.Getenv("PP_JIRA_USE_OAUTH1"))
+	if err != nil {
+		return err
+	}
+
 	s.clientManager, err = reqstats.New(reqstats.Opts{
 		Logger:                s.logger,
 		TLSInsecureSkipVerify: true,
-		SetOAuth1Client:       true,
+		SetOAuth1Client:       useOAuth1,
 		OAuth1ConsumerKey:     s.config.Username,
 		OAuth1Token:           s.config.Password,
 		OAuth1URL:             s.config.URL,

--- a/integrations/jira-hosted/integration.go
+++ b/integrations/jira-hosted/integration.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/pinpt/agent/integrations/jira/common"
 	"github.com/pinpt/agent/integrations/jira/commonapi"
+	"github.com/pinpt/agent/integrations/pkg/ibase"
 	"github.com/pinpt/agent/integrations/pkg/objsender"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/pinpt/agent/integrations/jira-hosted/api"
-	"github.com/pinpt/agent/integrations/pkg/ibase"
 	"github.com/pinpt/agent/rpcdef"
 	"github.com/pinpt/integration-sdk/work"
 )
@@ -86,10 +86,17 @@ func (s *Integration) initWithConfig(config rpcdef.ExportConfig, retryRequests b
 	s.qc.CustomerID = config.Pinpoint.CustomerID
 	s.qc.Logger = s.logger
 
-	s.clientManager = reqstats.New(reqstats.Opts{
+	s.clientManager, err = reqstats.New(reqstats.Opts{
 		Logger:                s.logger,
 		TLSInsecureSkipVerify: true,
+		SetOAuth1Client:       true,
+		OAuth1ConsumerKey:     s.config.Username,
+		OAuth1Token:           s.config.Password,
+		OAuth1URL:             s.config.URL,
 	})
+	if err != nil {
+		return err
+	}
 	s.clients = s.clientManager.Clients
 
 	{

--- a/integrations/jira-hosted/integration.go
+++ b/integrations/jira-hosted/integration.go
@@ -3,8 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/pinpt/agent/pkg/reqstats"
 	"github.com/pinpt/agent/pkg/structmarshal"
@@ -88,15 +86,9 @@ func (s *Integration) initWithConfig(config rpcdef.ExportConfig, retryRequests b
 	s.qc.CustomerID = config.Pinpoint.CustomerID
 	s.qc.Logger = s.logger
 
-	useOAuth1, err := strconv.ParseBool(os.Getenv("PP_JIRA_USE_OAUTH1"))
-	if err != nil {
-		return err
-	}
-
 	s.clientManager, err = reqstats.New(reqstats.Opts{
 		Logger:                s.logger,
 		TLSInsecureSkipVerify: true,
-		SetOAuth1Client:       useOAuth1,
 		OAuth1ConsumerKey:     s.config.Username,
 		OAuth1Token:           s.config.Password,
 		OAuth1URL:             s.config.URL,

--- a/integrations/jira-hosted/requester.go
+++ b/integrations/jira-hosted/requester.go
@@ -18,6 +18,7 @@ type RequesterOpts struct {
 	Password string
 
 	RetryRequests bool
+	UseOAuth1     bool
 }
 
 type Requester struct {
@@ -66,7 +67,9 @@ func (s *Requester) get(objPath string, params url.Values, res interface{}) (sta
 
 func (s *Requester) JSON(req requests.Request, res interface{}) (resp requests.Result, rerr error) {
 	var reqs requests.Requests
-	if s.opts.RetryRequests {
+	if s.opts.UseOAuth1 {
+		reqs = requests.New(s.logger, s.opts.Clients.OAuth1)
+	} else if s.opts.RetryRequests {
 		reqs = requests.NewRetryableDefault(s.logger, s.opts.Clients.TLSInsecure)
 	} else {
 		reqs = requests.New(s.logger, s.opts.Clients.TLSInsecure)

--- a/integrations/jira-hosted/requester.go
+++ b/integrations/jira-hosted/requester.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/url"
+	"os"
 
 	"github.com/pinpt/agent/pkg/reqstats"
 	"github.com/pinpt/agent/pkg/requests"
@@ -18,7 +19,6 @@ type RequesterOpts struct {
 	Password string
 
 	RetryRequests bool
-	UseOAuth1     bool
 }
 
 type Requester struct {
@@ -67,7 +67,7 @@ func (s *Requester) get(objPath string, params url.Values, res interface{}) (sta
 
 func (s *Requester) JSON(req requests.Request, res interface{}) (resp requests.Result, rerr error) {
 	var reqs requests.Requests
-	if s.opts.UseOAuth1 {
+	if os.Getenv("PP_JIRA_PRIVATE_KEY") != "" {
 		reqs = requests.New(s.logger, s.opts.Clients.OAuth1)
 	} else if s.opts.RetryRequests {
 		reqs = requests.NewRetryableDefault(s.logger, s.opts.Clients.TLSInsecure)

--- a/pkg/reqstats/oauth1.go
+++ b/pkg/reqstats/oauth1.go
@@ -16,7 +16,7 @@ import (
 
 func OAuth1HTTPClient(url, consumerKey, token string) (*http.Client, error) {
 	ctx := context.Background()
-	keyDERBlock, _ := pem.Decode([]byte(os.Getenv("OJA_JIRA_PRIVATE_KEY")))
+	keyDERBlock, _ := pem.Decode([]byte(os.Getenv("PP_JIRA_PRIVATE_KEY")))
 	if keyDERBlock == nil {
 		log.Fatal("unable to decode key PEM block")
 	}
@@ -41,7 +41,7 @@ func OAuth1HTTPClient(url, consumerKey, token string) (*http.Client, error) {
 		},
 	}
 
-	tok := &oauth1.Token{Token: token, TokenSecret: os.Getenv("OJA_JIRA_TOKEN_SECRET")}
+	tok := &oauth1.Token{Token: token, TokenSecret: os.Getenv("PP_JIRA_TOKEN_SECRET")}
 
 	return config.Client(ctx, tok), nil
 

--- a/pkg/reqstats/oauth1.go
+++ b/pkg/reqstats/oauth1.go
@@ -3,12 +3,10 @@ package reqstats
 import (
 	"context"
 	"crypto/x509"
-	"encoding/json"
 	"encoding/pem"
 	"log"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/dghubble/oauth1"
@@ -45,33 +43,4 @@ func OAuth1HTTPClient(url, consumerKey, token string) (*http.Client, error) {
 
 	return config.Client(ctx, tok), nil
 
-}
-
-func GetJIRAHTTPClient(ctx context.Context, config *oauth1.Config) (*http.Client, error) {
-	cacheFile, err := jiraTokenCacheFile()
-	if err != nil {
-		log.Fatalf("Unable to get path to cached credential file. %v", err)
-	}
-	tok, err := jiraTokenFromFile(cacheFile)
-	if err != nil {
-		return nil, err
-	}
-	return config.Client(ctx, tok), nil
-}
-
-func jiraTokenFromFile(file string) (*oauth1.Token, error) {
-	f, err := os.Open(file)
-	if err != nil {
-		return nil, err
-	}
-	t := &oauth1.Token{}
-	err = json.NewDecoder(f).Decode(t)
-	defer f.Close()
-	return t, err
-}
-
-func jiraTokenCacheFile() (string, error) {
-	tokenCacheDir := "/Users/carlos/go/src/github.com/pinpt/agent/support/oauthjiraagile/credentials"
-	os.MkdirAll(tokenCacheDir, 0700)
-	return filepath.Join(tokenCacheDir, "http%3A%2F%2Flocalhost%3A8084.json"), nil
 }

--- a/pkg/reqstats/oauth1.go
+++ b/pkg/reqstats/oauth1.go
@@ -1,0 +1,77 @@
+package reqstats
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dghubble/oauth1"
+)
+
+func OAuth1HTTPClient(url, consumerKey, token string) (*http.Client, error) {
+	ctx := context.Background()
+	keyDERBlock, _ := pem.Decode([]byte(os.Getenv("OJA_JIRA_PRIVATE_KEY")))
+	if keyDERBlock == nil {
+		log.Fatal("unable to decode key PEM block")
+	}
+	if !(keyDERBlock.Type == "PRIVATE KEY" || strings.HasSuffix(keyDERBlock.Type, " PRIVATE KEY")) {
+		log.Fatalf("unexpected key DER block type: %s", keyDERBlock.Type)
+	}
+
+	privateKey, err := x509.ParsePKCS1PrivateKey(keyDERBlock.Bytes)
+	if err != nil {
+		log.Fatalf("unable to parse PKCS1 private key. %v", err)
+	}
+	config := oauth1.Config{
+		ConsumerKey: consumerKey,
+		CallbackURL: "oob", /* for command line usage */
+		Endpoint: oauth1.Endpoint{
+			RequestTokenURL: url + "/plugins/servlet/oauth/request-token",
+			AuthorizeURL:    url + "/plugins/servlet/oauth/authorize",
+			AccessTokenURL:  url + "/plugins/servlet/oauth/access-token",
+		},
+		Signer: &oauth1.RSASigner{
+			PrivateKey: privateKey,
+		},
+	}
+
+	tok := &oauth1.Token{Token: token, TokenSecret: os.Getenv("OJA_JIRA_TOKEN_SECRET")}
+
+	return config.Client(ctx, tok), nil
+
+}
+
+func GetJIRAHTTPClient(ctx context.Context, config *oauth1.Config) (*http.Client, error) {
+	cacheFile, err := jiraTokenCacheFile()
+	if err != nil {
+		log.Fatalf("Unable to get path to cached credential file. %v", err)
+	}
+	tok, err := jiraTokenFromFile(cacheFile)
+	if err != nil {
+		return nil, err
+	}
+	return config.Client(ctx, tok), nil
+}
+
+func jiraTokenFromFile(file string) (*oauth1.Token, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	t := &oauth1.Token{}
+	err = json.NewDecoder(f).Decode(t)
+	defer f.Close()
+	return t, err
+}
+
+func jiraTokenCacheFile() (string, error) {
+	tokenCacheDir := "/Users/carlos/go/src/github.com/pinpt/agent/support/oauthjiraagile/credentials"
+	os.MkdirAll(tokenCacheDir, 0700)
+	return filepath.Join(tokenCacheDir, "http%3A%2F%2Flocalhost%3A8084.json"), nil
+}

--- a/pkg/reqstats/reqstats.go
+++ b/pkg/reqstats/reqstats.go
@@ -16,12 +16,17 @@ import (
 type Clients struct {
 	Default     *http.Client
 	TLSInsecure *http.Client
+	OAuth1      *http.Client
 }
 
 type Opts struct {
 	Logger hclog.Logger
 	// TLSInsecureSkipVerify to disable tls cert checks when integration uses TLSInsecure() client
 	TLSInsecureSkipVerify bool
+	SetOAuth1Client       bool
+	OAuth1ConsumerKey     string
+	OAuth1Token           string
+	OAuth1URL             string
 }
 
 type ClientManager struct {
@@ -38,7 +43,7 @@ func int64p() *int64 {
 	return &v
 }
 
-func New(opts Opts) *ClientManager {
+func New(opts Opts) (*ClientManager, error) {
 	if opts.Logger == nil {
 		panic("provide logger")
 	}
@@ -65,7 +70,15 @@ func New(opts Opts) *ClientManager {
 		s.Clients.TLSInsecure = c
 	}
 
-	return s
+	if opts.SetOAuth1Client {
+		oauthClient, err := OAuth1HTTPClient(opts.OAuth1URL, opts.OAuth1ConsumerKey, opts.OAuth1Token)
+		if err != nil {
+			return nil, err
+		}
+		s.Clients.OAuth1 = oauthClient
+	}
+
+	return s, nil
 }
 
 func (s ClientManager) PrintStats() string {

--- a/pkg/reqstats/reqstats.go
+++ b/pkg/reqstats/reqstats.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -23,7 +24,6 @@ type Opts struct {
 	Logger hclog.Logger
 	// TLSInsecureSkipVerify to disable tls cert checks when integration uses TLSInsecure() client
 	TLSInsecureSkipVerify bool
-	SetOAuth1Client       bool
 	OAuth1ConsumerKey     string
 	OAuth1Token           string
 	OAuth1URL             string
@@ -70,7 +70,7 @@ func New(opts Opts) (*ClientManager, error) {
 		s.Clients.TLSInsecure = c
 	}
 
-	if opts.SetOAuth1Client {
+	if os.Getenv("PP_JIRA_PRIVATE_KEY") != "" {
 		oauthClient, err := OAuth1HTTPClient(opts.OAuth1URL, opts.OAuth1ConsumerKey, opts.OAuth1Token)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
We need to set three env vars to temporarily make this work:

- PP_JIRA_PRIVATE_KEY
- PP_JIRA_TOKEN_SECRET

In the ui we need to set the ConsumerKey from the Jira Application Link in the username text field, and JiraOAuth1Token in the password text field.