### PR TITLE
🔇 Scrub out secret from logs 🧼

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -77,7 +77,7 @@ func getIntegration(ctx context.Context, logger log.Logger, channel string, dir 
 }
 
 func startIntegration(ctx context.Context, logger log.Logger, integrationExecutable string, cmdargs []string) (*exec.Cmd, error) {
-	log.Info(logger, "starting", "file", integrationExecutable, "args", cmdargs)
+	log.Info(logger, "starting", "file", integrationExecutable)
 	cm := exec.CommandContext(ctx, integrationExecutable, cmdargs...)
 	cm.Stdout = os.Stdout
 	cm.Stderr = os.Stderr


### PR DESCRIPTION
We have an automatic scrubber in the logger, but its not good enough for string arrays, seeing your own secret shouldnt really matter, but the fewer places it's displayed the better