### PR TITLE
GOLD-465 Added project_path to create issue mutation object

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -477,7 +477,7 @@ func Main(integration sdk.Integration, args ...string) {
 			datastr, _ := cmd.Flags().GetString("input")
 			data := make(map[string]interface{})
 			if err := json.Unmarshal([]byte(datastr), &data); err != nil {
-				log.Fatal(logger, "unable to decode mutation paylaod", "err", err)
+				log.Fatal(logger, "unable to decode mutation payload", "err", err)
 			}
 
 			var id string

--- a/sdk/mutation.go
+++ b/sdk/mutation.go
@@ -129,7 +129,7 @@ type WorkIssueCreateMutation struct {
 
 	// NOTE(robin): the above fields are for backwards compatibility, using MutationFields is the future 🚀
 	ProjectRefID string               `json:"project_ref_id"` // ProjectID is the id to the issue project as a ref_id
-	ProjectPath  string               `json:"project_path"`   // ProjectPath is the full path to the project
+	ProjectPath  *string              `json:"project_path"`   // ProjectPath is the full path to the project
 	Fields       []MutationFieldValue `json:"fields"`
 }
 

--- a/sdk/mutation.go
+++ b/sdk/mutation.go
@@ -128,8 +128,8 @@ type WorkIssueCreateMutation struct {
 	Labels        []string   `json:"labels,omitempty"`          // Labels is for setting the labels for an issue
 
 	// NOTE(robin): the above fields are for backwards compatibility, using MutationFields is the future 🚀
-	ProjectRefID string               `json:"project_ref_id"` // ProjectID is the id to the issue project as a ref_id
-	ProjectPath  *string              `json:"project_path"`   // ProjectPath is the full path to the project
+	ProjectRefID string               `json:"project_ref_id"` // ProjectID is the id to the issue project as a ref_id // DEPRECATED in favor of Project
+	Project      *NameRefID           `json:"project"`        // ProjectPath is the full path to the project
 	Fields       []MutationFieldValue `json:"fields"`
 }
 

--- a/sdk/mutation.go
+++ b/sdk/mutation.go
@@ -129,7 +129,7 @@ type WorkIssueCreateMutation struct {
 
 	// NOTE(robin): the above fields are for backwards compatibility, using MutationFields is the future 🚀
 	ProjectRefID string               `json:"project_ref_id"` // ProjectID is the id to the issue project as a ref_id // DEPRECATED in favor of Project
-	Project      *NameRefID           `json:"project"`        // ProjectPath is the full path to the project
+	Project      NameRefID            `json:"project"`        // Project contains ref_id and name of the project
 	Fields       []MutationFieldValue `json:"fields"`
 }
 

--- a/sdk/mutation.go
+++ b/sdk/mutation.go
@@ -129,6 +129,7 @@ type WorkIssueCreateMutation struct {
 
 	// NOTE(robin): the above fields are for backwards compatibility, using MutationFields is the future 🚀
 	ProjectRefID string               `json:"project_ref_id"` // ProjectID is the id to the issue project as a ref_id
+	ProjectPath  string               `json:"project_path"`   // ProjectPath is the full path to the project
 	Fields       []MutationFieldValue `json:"fields"`
 }
 


### PR DESCRIPTION
This would be useful as I couldn't find a way to create milestones using the graphQL api. 

Creating milestones using the rest api, forces me to know the project path to create the url I will send the request to, like `api.github.com/repos/pinpt/gitlab/milestones`.

We already have the project path in the first dropdown in the UI, I think this should be pretty easy to set there.