### PR TITLE
Error is checked but not displayed when an integration terminates

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -885,7 +885,7 @@ var runCmd = &cobra.Command{
 						if err != nil {
 							if currentCmd != nil && currentCmd.ProcessState != nil {
 								if currentCmd.ProcessState.ExitCode() != 0 {
-									log.Error(logger, "integration has exited", "restarted", restarted, "code", currentCmd.ProcessState.ExitCode())
+									log.Error(logger, "integration has exited", "restarted", restarted, "code", currentCmd.ProcessState.ExitCode(), "err", err)
 								}
 							}
 							log.Info(logger, "pausing", "duration", time.Second*time.Duration(restarted))


### PR DESCRIPTION
This prints it out so we can at least see whats up