### PR TITLE
Use the original publish endpoint now that it supports multipart

### DIFF
--- a/cmd/dev/publish.go
+++ b/cmd/dev/publish.go
@@ -132,7 +132,7 @@ var PublishCmd = &cobra.Command{
 			log.Fatal(logger, "error loading descriptor", "err", err, "file", descriptorFn)
 		}
 		version := getBuildCommitForIntegration(integrationDir)
-		basepath := fmt.Sprintf("publish2/%s/%s/%s", c.PublisherRefType, descriptor.RefType, version)
+		basepath := fmt.Sprintf("publish/%s/%s/%s", c.PublisherRefType, descriptor.RefType, version)
 		log.Info(logger, "uploading", "size", pnum.ToBytesSize(fiSize))
 		resp, err := api.Put(ctx, channel, api.RegistryService, basepath, apikey, rd, opts...)
 		if err := <-errs; err != nil {


### PR DESCRIPTION
@josecordaz I've ported the multipart handling into the old publish command so now we can move back to it